### PR TITLE
patch: fixed default policy.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,7 @@ class PolicyLoader {
             this.configuration = require(configurationFilePathByConvention);
         } catch {
             this.configuration = (policy) => {
-                policy.useMainline();
+                policy.useMainline('major:', 'minor:', 'patch:');
             };
         }
     }


### PR DESCRIPTION
Fixing a bug with the default policy that had no commit message prefixes (and so didn't match anything).